### PR TITLE
Add Initial Versions and Hand Tested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 
 charts/logging-central/charts
+charts/logging-central/requirements.lock
 charts/logging-central/logging-central-0.0.1.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+
+charts/logging-central/charts
+charts/logging-central/logging-central-0.0.1.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 
 charts/logging-central/charts
 charts/logging-central/requirements.lock
-charts/logging-central/logging-central-0.0.1.tgz
+charts/logging-central/logging-central-*.tgz

--- a/charts/logging-central/requirements.yaml
+++ b/charts/logging-central/requirements.yaml
@@ -8,7 +8,7 @@
 #       
 dependencies:
         #- name: elasticsearch
-        #version: 0.0.2
+        #version: ">=0.1.0-prod,<0.1.1-prod"
         #repository: http://charts.migrations.cnct.io
 - name: curator
   version: ">=0.0.6-prod,<0.0.7-prod"

--- a/charts/logging-central/requirements.yaml
+++ b/charts/logging-central/requirements.yaml
@@ -1,10 +1,18 @@
+#
+# NOTE: until helm issue 3947 is fixed, our chart version numbers are too long to list
+#       to get a full version number for pinning.
+#       e.g. charts.migrations.cnct.io/curator:0.0.6-prod.1+6b9ff26a9f8ee84d0760c68d117cb37677...
+#       (note the dots...)
+#       Using a range for now.
+#       (MLN 4/23/2018)
+#       
 dependencies:
-- name: elasticsearch
-  version: 0.0.2-0
-  repository: http://charts.migrations.cnct.io
+        #- name: elasticsearch
+        #version: 0.0.2
+        #repository: http://charts.migrations.cnct.io
 - name: curator
-  version: 0.0.3-0
+  version: ">=0.0.6-prod,<0.0.7-prod"
   repository: http://charts.migrations.cnct.io
 - name: kibana
-  version: 0.1.2-0
+  version: ">=0.1.4-prod,<0.1.5-prod"
   repository: http://charts.migrations.cnct.io

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -6,6 +6,9 @@ configs:
       values:
     stage: 
       values:
+helmRepos:
+   - name: cnct-migrations
+     url: http://charts.migrations.cnct.io
 prod: 
   doDeploy: none
   #doDeploy: versionfile


### PR DESCRIPTION
Initial versions populated with a range, until the Helm update occurs that allows printing the full version address, so we can then pin it in the requirements.yaml.

requirements.lock is NOT checked in, as it is always rebuilt (currently) in our system.

NOTE: (elasticsearch is commented out to allow a real build to occur.  It has to be added back in when it is available in the chart repo).

These changes were tested by hand and successfully run on a dev cluster.   Automated testing is still should be added.

